### PR TITLE
Apply Reflink fixes from Marked 4.0.16

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default function() {
                 row = item.header[j];
                 for (k = 0; k < row.length; k++) {
                   row[k].tokens = [];
-                  this.lexer.inlineTokens(row[k].text, row[k].tokens);
+                  this.lexer.inline(row[k].text, row[k].tokens);
                 }
               }
 
@@ -79,7 +79,7 @@ export default function() {
                 row = item.rows[j];
                 for (k = 0; k < row.length; k++) {
                   row[k].tokens = [];
-                  this.lexer.inlineTokens(row[k].text, row[k].tokens);
+                  this.lexer.inline(row[k].text, row[k].tokens);
                 }
               }
               return item;


### PR DESCRIPTION
Change inlinetokens to inline. Ensures internal parsing doesn't occur until all block-level parsing has happened, when reflinks are ready