### PR TITLE
Column widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Headers can now follow the same structure as cells, to include multiple rows, an
 ```
 
 ## Column widths
-Column widths may be set by percentage.
+Column widths may be set by percentage. At least one hyphen on is required on each side of the width value, padding with spaces allowed: `|-10%-|` or `|- 10% -|`.
 
 ```
 |Column One|Column Two|Column Three|
-|--10%-----|---40%----|----50%-----|
+|--10%-----|-- 40% ---|:---50%-----|
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Headers can now follow the same structure as cells, to include multiple rows, an
 | Cell A      | Cell B     | Cell C   |
 ```
 
+## Column widths
+Column widths may be set by percentage.
+
+```
+|Column One|Column Two|Column Three|
+|--10%-----|---40%----|----50%-----|
+```
+
 # Usage
 <!-- Show most examples of how to use this extension -->
 

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -10,7 +10,7 @@ function index(endRegex = []) {
         tokenizer(src, tokens) {
           // const regex = this.tokenizer.rules.block.table;
           let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-              + ' {0,3}(?:\\| *)?(:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *(?:\\| *:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *)*)(?:\\| *)?' // Align
+              + ' {0,3}(?:\\| *)?(:?-+(?: *(?:100|[1-9][0-9]?%) *-)?-*:? *(?:\\| *:?-+(?: *(?:100|[1-9][0-9]?%) *-)?-*:? *)*)(?:\\| *)?' // Align
               + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
               + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
               + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -22,20 +22,21 @@ function index(endRegex = []) {
               + '|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)'
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
+					//[1-9]|[1-9][0-9]|100)%
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-          const widthRegex = /(([1-9]|[1-9][0-9]|100)\%)/;
+          const widthRegex = /(?:100|[1-9][0-9]?%)/g;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
-
+					console.log(cap);
           if (cap) {
             const item = {
               type: 'spanTable',
               header: cap[1].replace(/\n$/, '').split('\n'),
-              align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-              rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
-              widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
+              align: cap[2].replace(widthRegex, '').replace(/^ *|\| *$/g, '').split(/ *\| */),
+              rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
+              width: cap[2].replace(/:/g, '').replace(/-+| /g, '').split('|')
             };
-
+						console.log(item);
             // Get first header row to determine how many columns
             item.header[0] = splitCells(item.header[0]);
 
@@ -52,13 +53,6 @@ function index(endRegex = []) {
               let l = item.align.length;
 
               for (i = 0; i < l; i++) {
-                // Strip width declarations first.
-                const match = widthRegex.exec(item.align[i]);
-                if (match?.length) {
-                  item.widths[i] = match[1];
-                  item.align[i] = `${item.align[i].slice(0, match.index)}${item.align[i].slice(match.index + match[0].length)}`;
-                  console.log(item.align[i]);
-                }
                 if (/^ *-+: *$/.test(item.align[i])) {
                   item.align[i] = 'right';
                 } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -108,15 +102,6 @@ function index(endRegex = []) {
         renderer(token) {
           let i, j, row, cell, col, text;
           let output = '<table>';
-          // Add column specs
-          if (token.widths?.length > 0) {
-            output += '<colgroup>';
-            for (i = 0; i < token.widths.length; i++) {
-              if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
-              else output += '<col />';
-            }
-            output += '</colgroup>';
-          }
           output += '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];
@@ -125,7 +110,7 @@ function index(endRegex = []) {
             for (j = 0; j < row.length; j++) {
               cell = row[j];
               text = this.parser.parseInline(cell.tokens);
-              output += getTableCell(text, cell, 'th', token.align[col]);
+              output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
               col += cell.colspan;
             }
             output += '</tr>';
@@ -140,7 +125,7 @@ function index(endRegex = []) {
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                output += getTableCell(text, cell, 'td', token.align[col]);
+                output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                 col += cell.colspan;
               }
               output += '</tr>';
@@ -155,14 +140,15 @@ function index(endRegex = []) {
   };
 }
 
-const getTableCell = (text, cell, type, align) => {
+const getTableCell = (text, cell, type, align, width) => {
   if (!cell.rowspan) {
     return '';
   }
   const tag = `<${type}`
             + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
             + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`
-            + `${align ? ` align=${align}` : ''}>`;
+            + `${align ? ` align=${align}` : ''}`
+						+ `${width ? ` width=${width}` : ''}>`;
   return `${tag + text}</${type}>\n`;
 };
 

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -23,6 +23,7 @@ function index(endRegex = []) {
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
+          const widthRegex = /(([1-9]|[1-9][0-9]|100)\%)/;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
 
@@ -34,8 +35,6 @@ function index(endRegex = []) {
               rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
               widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
             };
-
-            console.log(item.widths);
 
             // Get first header row to determine how many columns
             item.header[0] = splitCells(item.header[0]);
@@ -54,11 +53,12 @@ function index(endRegex = []) {
 
               for (i = 0; i < l; i++) {
                 // Strip width declarations first.
-                // const match = widthRegex.exec(item.align[i]);
-                // if (match?.length) {
-                //   item.widths[i] = match[1];
-                //   item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
-                // }
+                const match = widthRegex.exec(item.align[i]);
+                if (match?.length) {
+                  item.widths[i] = match[1];
+                  item.align[i] = `${item.align[i].slice(0, match.index)}${item.align[i].slice(match.index + match[0].length)}`;
+                  console.log(item.align[i]);
+                }
                 if (/^ *-+: *$/.test(item.align[i])) {
                   item.align[i] = 'right';
                 } else if (/^ *:-+: *$/.test(item.align[i])) {

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -10,7 +10,7 @@ function index(endRegex = []) {
         tokenizer(src, tokens) {
           // const regex = this.tokenizer.rules.block.table;
           let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-              + ' {0,3}(?:\\| *)?(:?-+(([1-9]|[1-9][0-9]|100)\%)?-+:? *(?:\\| *:?-+:? *)*)(?:\\| *)?' // Align
+              + ' {0,3}(?:\\| *)?(:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *(?:\\| *:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *)*)(?:\\| *)?' // Align
               + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
               + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
               + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -23,7 +23,6 @@ function index(endRegex = []) {
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-          const widthRegex = /-(([1-9]|[1-9][0-9]|100)\%)-/;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
 
@@ -32,9 +31,11 @@ function index(endRegex = []) {
               type: 'spanTable',
               header: cap[1].replace(/\n$/, '').split('\n'),
               align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-              rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
-              widths: []
+              rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
+              widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
             };
+
+            console.log(item.widths);
 
             // Get first header row to determine how many columns
             item.header[0] = splitCells(item.header[0]);
@@ -53,11 +54,11 @@ function index(endRegex = []) {
 
               for (i = 0; i < l; i++) {
                 // Strip width declarations first.
-                const match = widthRegex.exec(item.align[i]);
-                if (match?.length) {
-                  item.widths[i] = match[1];
-                  item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
-                }
+                // const match = widthRegex.exec(item.align[i]);
+                // if (match?.length) {
+                //   item.widths[i] = match[1];
+                //   item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
+                // }
                 if (/^ *-+: *$/.test(item.align[i])) {
                   item.align[i] = 'right';
                 } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -110,7 +111,7 @@ function index(endRegex = []) {
           // Add column specs
           if (token.widths?.length > 0) {
             output += '<colgroup>';
-            for (i = 0; i < token.header.length; i++) {
+            for (i = 0; i < token.widths.length; i++) {
               if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
               else output += '<col />';
             }

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -10,7 +10,7 @@ function index(endRegex = []) {
         tokenizer(src, tokens) {
           // const regex = this.tokenizer.rules.block.table;
           let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-              + ' {0,3}(?:\\| *)?(:?-+:? *(?:\\| *:?-+:? *)*)(?:\\| *)?' // Align
+              + ' {0,3}(?:\\| *)?(:?-+(([1-9]|[1-9][0-9]|100)\%)?-+:? *(?:\\| *:?-+:? *)*)(?:\\| *)?' // Align
               + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
               + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
               + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -23,6 +23,7 @@ function index(endRegex = []) {
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
+          const widthRegex = /-(([1-9]|[1-9][0-9]|100)\%)-/;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
 
@@ -31,7 +32,8 @@ function index(endRegex = []) {
               type: 'spanTable',
               header: cap[1].replace(/\n$/, '').split('\n'),
               align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-              rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : []
+              rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
+              widths: []
             };
 
             // Get first header row to determine how many columns
@@ -50,6 +52,12 @@ function index(endRegex = []) {
               let l = item.align.length;
 
               for (i = 0; i < l; i++) {
+                // Strip width declarations first.
+                const match = widthRegex.exec(item.align[i]);
+                if (match?.length) {
+                  item.widths[i] = match[1];
+                  item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
+                }
                 if (/^ *-+: *$/.test(item.align[i])) {
                   item.align[i] = 'right';
                 } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -99,6 +107,15 @@ function index(endRegex = []) {
         renderer(token) {
           let i, j, row, cell, col, text;
           let output = '<table>';
+          // Add column specs
+          if (token.widths?.length > 0) {
+            output += '<colgroup>';
+            for (i = 0; i < token.header.length; i++) {
+              if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
+              else output += '<col />';
+            }
+            output += '</colgroup>';
+          }
           output += '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -22,12 +22,11 @@ function index(endRegex = []) {
               + '|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)'
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
-					//[1-9]|[1-9][0-9]|100)%
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
           const widthRegex = /(?:100|[1-9][0-9]?%)/g;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
-					console.log(cap);
+
           if (cap) {
             const item = {
               type: 'spanTable',
@@ -36,7 +35,7 @@ function index(endRegex = []) {
               rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
               width: cap[2].replace(/:/g, '').replace(/-+| /g, '').split('|')
             };
-						console.log(item);
+
             // Get first header row to determine how many columns
             item.header[0] = splitCells(item.header[0]);
 
@@ -148,7 +147,7 @@ const getTableCell = (text, cell, type, align, width) => {
             + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
             + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`
             + `${align ? ` align=${align}` : ''}`
-						+ `${width ? ` width=${width}` : ''}>`;
+            + `${width ? ` width=${width}` : ''}>`;
   return `${tag + text}</${type}>\n`;
 };
 

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -14,7 +14,7 @@
           tokenizer(src, tokens) {
             // const regex = this.tokenizer.rules.block.table;
             let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-                + ' {0,3}(?:\\| *)?(:?-+(([1-9]|[1-9][0-9]|100)\%)?-+:? *(?:\\| *:?-+:? *)*)(?:\\| *)?' // Align
+                + ' {0,3}(?:\\| *)?(:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *(?:\\| *:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *)*)(?:\\| *)?' // Align
                 + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
                 + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
                 + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -27,7 +27,6 @@
                 + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
             regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-            const widthRegex = /-(([1-9]|[1-9][0-9]|100)\%)-/;
             const regex = new RegExp(regexString);
             const cap = regex.exec(src);
 
@@ -36,9 +35,11 @@
                 type: 'spanTable',
                 header: cap[1].replace(/\n$/, '').split('\n'),
                 align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-                rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
-                widths: []
+                rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
+                widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
               };
+
+              console.log(item.widths);
 
               // Get first header row to determine how many columns
               item.header[0] = splitCells(item.header[0]);
@@ -57,11 +58,11 @@
 
                 for (i = 0; i < l; i++) {
                   // Strip width declarations first.
-                  const match = widthRegex.exec(item.align[i]);
-                  if (match?.length) {
-                    item.widths[i] = match[1];
-                    item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
-                  }
+                  // const match = widthRegex.exec(item.align[i]);
+                  // if (match?.length) {
+                  //   item.widths[i] = match[1];
+                  //   item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
+                  // }
                   if (/^ *-+: *$/.test(item.align[i])) {
                     item.align[i] = 'right';
                   } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -114,7 +115,7 @@
             // Add column specs
             if (token.widths?.length > 0) {
               output += '<colgroup>';
-              for (i = 0; i < token.header.length; i++) {
+              for (i = 0; i < token.widths.length; i++) {
                 if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
                 else output += '<col />';
               }

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -14,7 +14,7 @@
           tokenizer(src, tokens) {
             // const regex = this.tokenizer.rules.block.table;
             let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-                + ' {0,3}(?:\\| *)?(:?-+:? *(?:\\| *:?-+:? *)*)(?:\\| *)?' // Align
+                + ' {0,3}(?:\\| *)?(:?-+(([1-9]|[1-9][0-9]|100)\%)?-+:? *(?:\\| *:?-+:? *)*)(?:\\| *)?' // Align
                 + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
                 + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
                 + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -27,6 +27,7 @@
                 + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
             regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
+            const widthRegex = /-(([1-9]|[1-9][0-9]|100)\%)-/;
             const regex = new RegExp(regexString);
             const cap = regex.exec(src);
 
@@ -35,7 +36,8 @@
                 type: 'spanTable',
                 header: cap[1].replace(/\n$/, '').split('\n'),
                 align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-                rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : []
+                rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
+                widths: []
               };
 
               // Get first header row to determine how many columns
@@ -54,6 +56,12 @@
                 let l = item.align.length;
 
                 for (i = 0; i < l; i++) {
+                  // Strip width declarations first.
+                  const match = widthRegex.exec(item.align[i]);
+                  if (match?.length) {
+                    item.widths[i] = match[1];
+                    item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
+                  }
                   if (/^ *-+: *$/.test(item.align[i])) {
                     item.align[i] = 'right';
                   } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -103,6 +111,15 @@
           renderer(token) {
             let i, j, row, cell, col, text;
             let output = '<table>';
+            // Add column specs
+            if (token.widths?.length > 0) {
+              output += '<colgroup>';
+              for (i = 0; i < token.header.length; i++) {
+                if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
+                else output += '<col />';
+              }
+              output += '</colgroup>';
+            }
             output += '<thead>';
             for (i = 0; i < token.header.length; i++) {
               row = token.header[i];

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -26,12 +26,11 @@
                 + '|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)'
                 + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
-  					//[1-9]|[1-9][0-9]|100)%
             regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
             const widthRegex = /(?:100|[1-9][0-9]?%)/g;
             const regex = new RegExp(regexString);
             const cap = regex.exec(src);
-  					console.log(cap);
+
             if (cap) {
               const item = {
                 type: 'spanTable',
@@ -40,7 +39,7 @@
                 rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
                 width: cap[2].replace(/:/g, '').replace(/-+| /g, '').split('|')
               };
-  						console.log(item);
+
               // Get first header row to determine how many columns
               item.header[0] = splitCells(item.header[0]);
 
@@ -152,7 +151,7 @@
               + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
               + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`
               + `${align ? ` align=${align}` : ''}`
-  						+ `${width ? ` width=${width}` : ''}>`;
+              + `${width ? ` width=${width}` : ''}>`;
     return `${tag + text}</${type}>\n`;
   };
 

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -27,6 +27,7 @@
                 + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
             regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
+            const widthRegex = /(([1-9]|[1-9][0-9]|100)\%)/;
             const regex = new RegExp(regexString);
             const cap = regex.exec(src);
 
@@ -38,8 +39,6 @@
                 rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
                 widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
               };
-
-              console.log(item.widths);
 
               // Get first header row to determine how many columns
               item.header[0] = splitCells(item.header[0]);
@@ -58,11 +57,12 @@
 
                 for (i = 0; i < l; i++) {
                   // Strip width declarations first.
-                  // const match = widthRegex.exec(item.align[i]);
-                  // if (match?.length) {
-                  //   item.widths[i] = match[1];
-                  //   item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
-                  // }
+                  const match = widthRegex.exec(item.align[i]);
+                  if (match?.length) {
+                    item.widths[i] = match[1];
+                    item.align[i] = `${item.align[i].slice(0, match.index)}${item.align[i].slice(match.index + match[0].length)}`;
+                    console.log(item.align[i]);
+                  }
                   if (/^ *-+: *$/.test(item.align[i])) {
                     item.align[i] = 'right';
                   } else if (/^ *:-+: *$/.test(item.align[i])) {

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -27,7 +27,7 @@
                 + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
             regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-            const widthRegex = /(?:100|[1-9][0-9]?%)/g;
+            const widthRegex = / *(?:100|[1-9][0-9]?%) */g;
             const regex = new RegExp(regexString);
             const cap = regex.exec(src);
 

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -14,7 +14,7 @@
           tokenizer(src, tokens) {
             // const regex = this.tokenizer.rules.block.table;
             let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-                + ' {0,3}(?:\\| *)?(:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *(?:\\| *:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *)*)(?:\\| *)?' // Align
+                + ' {0,3}(?:\\| *)?(:?-+(?: *(?:100|[1-9][0-9]?%) *-)?-*:? *(?:\\| *:?-+(?: *(?:100|[1-9][0-9]?%) *-)?-*:? *)*)(?:\\| *)?' // Align
                 + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
                 + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
                 + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -26,20 +26,21 @@
                 + '|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)'
                 + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
+  					//[1-9]|[1-9][0-9]|100)%
             regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-            const widthRegex = /(([1-9]|[1-9][0-9]|100)\%)/;
+            const widthRegex = /(?:100|[1-9][0-9]?%)/g;
             const regex = new RegExp(regexString);
             const cap = regex.exec(src);
-
+  					console.log(cap);
             if (cap) {
               const item = {
                 type: 'spanTable',
                 header: cap[1].replace(/\n$/, '').split('\n'),
-                align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-                rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
-                widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
+                align: cap[2].replace(widthRegex, '').replace(/^ *|\| *$/g, '').split(/ *\| */),
+                rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
+                width: cap[2].replace(/:/g, '').replace(/-+| /g, '').split('|')
               };
-
+  						console.log(item);
               // Get first header row to determine how many columns
               item.header[0] = splitCells(item.header[0]);
 
@@ -56,13 +57,6 @@
                 let l = item.align.length;
 
                 for (i = 0; i < l; i++) {
-                  // Strip width declarations first.
-                  const match = widthRegex.exec(item.align[i]);
-                  if (match?.length) {
-                    item.widths[i] = match[1];
-                    item.align[i] = `${item.align[i].slice(0, match.index)}${item.align[i].slice(match.index + match[0].length)}`;
-                    console.log(item.align[i]);
-                  }
                   if (/^ *-+: *$/.test(item.align[i])) {
                     item.align[i] = 'right';
                   } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -112,15 +106,6 @@
           renderer(token) {
             let i, j, row, cell, col, text;
             let output = '<table>';
-            // Add column specs
-            if (token.widths?.length > 0) {
-              output += '<colgroup>';
-              for (i = 0; i < token.widths.length; i++) {
-                if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
-                else output += '<col />';
-              }
-              output += '</colgroup>';
-            }
             output += '<thead>';
             for (i = 0; i < token.header.length; i++) {
               row = token.header[i];
@@ -129,7 +114,7 @@
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                output += getTableCell(text, cell, 'th', token.align[col]);
+                output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
                 col += cell.colspan;
               }
               output += '</tr>';
@@ -144,7 +129,7 @@
                 for (j = 0; j < row.length; j++) {
                   cell = row[j];
                   text = this.parser.parseInline(cell.tokens);
-                  output += getTableCell(text, cell, 'td', token.align[col]);
+                  output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                   col += cell.colspan;
                 }
                 output += '</tr>';
@@ -159,14 +144,15 @@
     };
   }
 
-  const getTableCell = (text, cell, type, align) => {
+  const getTableCell = (text, cell, type, align, width) => {
     if (!cell.rowspan) {
       return '';
     }
     const tag = `<${type}`
               + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
               + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`
-              + `${align ? ` align=${align}` : ''}>`;
+              + `${align ? ` align=${align}` : ''}`
+  						+ `${width ? ` width=${width}` : ''}>`;
     return `${tag + text}</${type}>\n`;
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "semantic-release": "^24.1.0"
       },
       "peerDependencies": {
-        "marked": "^14.1.0"
+        "marked": ">=3 <15"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -47,3 +47,41 @@ exports[`extended-table Stops at custom terminators 1`] = `
 </tr></tbody></table><p>aaaa</p>
 "
 `;
+
+exports[`extended-table Works with combined widths and alignment 1`] = `
+"<table><thead><tr><th align=left width=10%>Header A</th>
+<th align=center width=20%>Header B</th>
+<th align=right width=50%>Header C</th>
+</tr></thead><tbody><tr><td align=left width=10%>Cell A</td>
+<td align=center width=20%>Cell B</td>
+<td align=right width=50%>Cell C</td>
+</tr></tbody></table>"
+`;
+
+exports[`extended-table Works with minimal delimiter rows 1`] = `
+"<table><thead><tr><th>Header A</th>
+<th align=left>Header B</th>
+<th align=right>Header C</th>
+<th align=center>Header D</th>
+</tr></thead><tbody><tr><td>Cell A</td>
+<td align=left>Cell B</td>
+<td align=right>Cell C</td>
+<td align=center>Cell D</td>
+</tr></tbody></table>"
+`;
+
+exports[`extended-table Works with mix of widths and not 1`] = `
+"<table><thead><tr><th width=10%>Header A</th>
+<th>Header B</th>
+<th width=50%>Header C</th>
+</tr></thead><tbody><tr><td width=10%>Cell A</td>
+<td>Cell B</td>
+<td width=50%>Cell C</td>
+</tr></tbody></table>"
+`;
+
+exports[`extended-table Works with percentage widths 1`] = `
+"<table><thead><tr><th width=10%>Header A</th>
+</tr></thead><tbody><tr><td width=10%>Cell A</td>
+</tr></tbody></table>"
+`;

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -61,4 +61,40 @@ describe('extended-table', () => {
       cccc
     `))).toMatchSnapshot();
   });
+
+	test('Works with minimal delimiter rows', () => {
+    marked.use(extendedTable());
+    expect(marked(trimLines(`
+      | Header A | Header B | Header C | Header D |
+      |-|:-|-:|:-:|
+      | Cell A   | Cell B   | Cell C   | Cell D   |
+    `))).toMatchSnapshot();
+  });
+
+	test('Works with percentage widths', () => {
+    marked.use(extendedTable());
+    expect(marked(trimLines(`
+      | Header A |
+      |---10%----|
+      | Cell A   |
+    `))).toMatchSnapshot();
+  });
+
+	test('Works with mix of widths and not', () => {
+    marked.use(extendedTable());
+    expect(marked(trimLines(`
+      | Header A | Header B | Header C |
+      |---10%----|----------|--- 50% --|
+      | Cell A   | Cell B   | Cell C   |
+    `))).toMatchSnapshot();
+  });
+
+	test('Works with combined widths and alignment', () => {
+    marked.use(extendedTable());
+    expect(marked(trimLines(`
+      | Header A | Header B | Header C |
+      |:---10%---|:---20%--:|---50%---:|
+      | Cell A   | Cell B   | Cell C   |
+    `))).toMatchSnapshot();
+  });
 });

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -93,7 +93,7 @@ describe('extended-table', () => {
     marked.use(extendedTable());
     expect(marked(trimLines(`
       | Header A | Header B | Header C |
-      |:---10%---|:---20%--:|---50%---:|
+      |:---10%---|:-- 20% -:|---50%---:|
       | Cell A   | Cell B   | Cell C   |
     `))).toMatchSnapshot();
   });

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export default function(endRegex = []) {
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
+          const widthRegex = /(([1-9]|[1-9][0-9]|100)\%)/;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
 
@@ -49,6 +50,12 @@ export default function(endRegex = []) {
               let l = item.align.length;
 
               for (i = 0; i < l; i++) {
+                // Strip width declarations first.
+                const match = widthRegex.exec(item.align[i]);
+                if (match?.length) {
+                  item.widths[i] = match[1];
+                  item.align[i] = `${item.align[i].slice(0, match.index)}${item.align[i].slice(match.index + match[0].length)}`;
+                }
                 if (/^ *-+: *$/.test(item.align[i])) {
                   item.align[i] = 'right';
                 } else if (/^ *:-+: *$/.test(item.align[i])) {

--- a/src/index.js
+++ b/src/index.js
@@ -99,15 +99,6 @@ export default function(endRegex = []) {
         renderer(token) {
           let i, j, row, cell, col, text;
           let output = '<table>';
-          // Add column specs
-          if (token.widths?.length > 0) {
-            output += '<colgroup>';
-            for (i = 0; i < token.widths.length; i++) {
-              if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
-              else output += '<col />';
-            }
-            output += '</colgroup>';
-          }
           output += '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];
@@ -116,7 +107,7 @@ export default function(endRegex = []) {
             for (j = 0; j < row.length; j++) {
               cell = row[j];
               text = this.parser.parseInline(cell.tokens);
-              output += getTableCell(text, cell, 'th', token.align[col]);
+              output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
               col += cell.colspan;
             }
             output += '</tr>';
@@ -131,7 +122,7 @@ export default function(endRegex = []) {
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                output += getTableCell(text, cell, 'td', token.align[col]);
+                output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                 col += cell.colspan;
               }
               output += '</tr>';
@@ -146,14 +137,15 @@ export default function(endRegex = []) {
   };
 }
 
-const getTableCell = (text, cell, type, align) => {
+const getTableCell = (text, cell, type, align, width) => {
   if (!cell.rowspan) {
     return '';
   }
   const tag = `<${type}`
             + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
             + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`
-            + `${align ? ` align=${align}` : ''}>`;
+            + `${align ? ` align=${align}` : ''}`
+            + `${width ? ` width=${width}` : ''}>`;
   return `${tag + text}</${type}>\n`;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function(endRegex = []) {
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-          const widthRegex = /(?:100|[1-9][0-9]?%)/g;
+          const widthRegex = / *(?:100|[1-9][0-9]?%) */g;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default function(endRegex = []) {
         tokenizer(src, tokens) {
           // const regex = this.tokenizer.rules.block.table;
           let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-              + ' {0,3}(?:\\| *)?(:?-+(([1-9]|[1-9][0-9]|100)\%)?-+:? *(?:\\| *:?-+:? *)*)(?:\\| *)?' // Align
+              + ' {0,3}(?:\\| *)?(:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *(?:\\| *:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *)*)(?:\\| *)?' // Align
               + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
               + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
               + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -21,9 +21,6 @@ export default function(endRegex = []) {
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-          const alignRegex = /\\|:?-+(([1-9]|[1-9][0-9]|100)\%)-+:?\\|/gm;
-          const widthRegex = /-(([1-9]|[1-9][0-9]|100)\%)-/;
-          const alignMatch = alignRegex.exec(src);
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
 
@@ -32,8 +29,8 @@ export default function(endRegex = []) {
               type: 'spanTable',
               header: cap[1].replace(/\n$/, '').split('\n'),
               align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-              rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
-              widths: []
+              rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
+              widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
             };
 
             // Get first header row to determine how many columns
@@ -52,12 +49,6 @@ export default function(endRegex = []) {
               let l = item.align.length;
 
               for (i = 0; i < l; i++) {
-                // Strip width declarations first.
-                const match = widthRegex.exec(item.align[i]);
-                if (match?.length) {
-                  item.widths[i] = match[1];
-                  item.align[i] = item.align[i].slice(match.index + 1, -1 * (match[1].length - 1));
-                }
                 if (/^ *-+: *$/.test(item.align[i])) {
                   item.align[i] = 'right';
                 } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -110,7 +101,7 @@ export default function(endRegex = []) {
           // Add column specs
           if (token.widths?.length > 0) {
             output += '<colgroup>';
-            for (i = 0; i < token.header.length; i++) {
+            for (i = 0; i < token.widths.length; i++) {
               if (token.widths[i]) output += `<col style="width:${token.widths[i]}" />`;
               else output += '<col />';
             }

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default function(endRegex = []) {
             const item = {
               type: 'spanTable',
               header: cap[1].replace(/\n$/, '').split('\n'),
-              align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+              align: cap[2].replace(widthRegex, '').replace(/^ *|\| *$/g, '').split(/ *\| */),
               rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
               width: cap[2].replace(/:/g, '').replace(/-+| /g, '').split('|')
             };
@@ -50,12 +50,6 @@ export default function(endRegex = []) {
               let l = item.align.length;
 
               for (i = 0; i < l; i++) {
-                // Strip width declarations first.
-                const match = widthRegex.exec(item.align[i]);
-                if (match?.length) {
-                  item.widths[i] = match[1];
-                  item.align[i] = `${item.align[i].slice(0, match.index)}${item.align[i].slice(match.index + match[0].length)}`;
-                }
                 if (/^ *-+: *$/.test(item.align[i])) {
                   item.align[i] = 'right';
                 } else if (/^ *:-+: *$/.test(item.align[i])) {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default function(endRegex = []) {
         tokenizer(src, tokens) {
           // const regex = this.tokenizer.rules.block.table;
           let regexString = '^ *([^\\n ].*\\|.*\\n(?: *[^\\s].*\\n)*?)' // Header
-              + ' {0,3}(?:\\| *)?(:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *(?:\\| *:?-+(?:([1-9]|[1-9][0-9]|100)%)?-+:? *)*)(?:\\| *)?' // Align
+              + ' {0,3}(?:\\| *)?(:?-+(?: *(?:100|[1-9][0-9]?%) *-)?-*:? *(?:\\| *:?-+(?: *(?:100|[1-9][0-9]?%) *-)?-*:? *)*)(?:\\| *)?' // Align
               + '(?:\\n((?:(?! *\\n| {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})' // Cells
               + '(?:\\n+|$)| {0,3}#{1,6} | {0,3}>| {4}[^\\n]| {0,3}(?:`{3,}'
               + '(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n| {0,3}(?:[*+-]|1[.)]) |'
@@ -21,7 +21,7 @@ export default function(endRegex = []) {
               + '(?: +|\\n|\\/?>)|<(?:script|pre|style|textarea|!--)endRegex).*(?:\\n|$))*)\\n*|$)'; // Cells
 
           regexString = regexString.replace('endRegex', endRegex.map(str => `|(?:${str})`).join(''));
-          const widthRegex = /(([1-9]|[1-9][0-9]|100)\%)/;
+          const widthRegex = /(?:100|[1-9][0-9]?%)/g;
           const regex = new RegExp(regexString);
           const cap = regex.exec(src);
 
@@ -30,8 +30,8 @@ export default function(endRegex = []) {
               type: 'spanTable',
               header: cap[1].replace(/\n$/, '').split('\n'),
               align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-              rows: cap[5] ? cap[5].replace(/\n$/, '').split('\n') : [],
-              widths: cap[2].replace(/:/g, '').replace(/-+/g, '').split('|')
+              rows: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
+              width: cap[2].replace(/:/g, '').replace(/-+| /g, '').split('|')
             };
 
             // Get first header row to determine how many columns


### PR DESCRIPTION
This adds setting column widths in colgroups as a percentage.

##### Example With Alignment and Without Widths

| Head A | Spanned Header ||
| Head B | Head C | Head D |
|:-------|:------:|-------:|
| 1A     |    1B  |    1C  |
| 2A    ^|    2B  |    2C  |
| 3A    ^|    3B       3C ||
| 4A     |    4B       4C^||
| 5A    ^|    5B  |    5C  |
| 6A     |    6B ^|    6C  |

##### Example With Alignment and Widths 

```
| Head A | Spanned Header ||
| Head B | Head C | Head D |
|:--20%--|:-50%--:|--20%--:|
| 1A     |    1B  |    1C  |
| 2A    ^|    2B  |    2C  |
| 3A    ^|    3B       3C ||
| 4A     |    4B       4C^||
| 5A    ^|    5B  |    5C  |
| 6A     |    6B ^|    6C  |
```

##### Example Without Alignment and Widths 

```
| Head A | Spanned Header ||
| Head B | Head C | Head D |
|---20%--|--50%---|--20%---|
| 1A     |    1B  |    1C  |
| 2A    ^|    2B  |    2C  |
| 3A    ^|    3B       3C ||
| 4A     |    4B       4C^||
| 5A    ^|    5B  |    5C  |
| 6A     |    6B ^|    6C  |
```

![ColumnWdiths](https://github.com/user-attachments/assets/3aabce4b-f881-4699-a671-810176997753)
