### PR TITLE
Fix for nth-child issues caused by empty TRs

### DIFF
--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -116,20 +116,18 @@ function index(endRegex = []) {
           }
           output += '</thead>';
           if (token.rows.length) {
-            output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {
               row = token.rows[i];
               col = 0;
-              output += '<tr>';
+              let trContents = '';
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                 col += cell.colspan;
               }
-              output += '</tr>';
+              if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
             }
-            output += '</tbody>';
           }
           output += '</table>';
           return output;

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -1,11 +1,14 @@
 'use strict';
 
+let singleTBody = true;
+
 function index(endRegex = []) {
   return {
     extensions: [
       {
         name: 'spanTable',
         level: 'block', // Is this a block-level or inline-level tokenizer?
+        setMode(mode) { if (typeof mode === 'boolean') singleTBody = mode; },
         start(src) { return src.match(/^\n *([^\n ].*\|.*)\n/)?.index; }, // Hint to Marked.js to stop and check for a match
         tokenizer(src, tokens) {
           // const regex = this.tokenizer.rules.block.table;
@@ -116,18 +119,23 @@ function index(endRegex = []) {
           }
           output += '</thead>';
           if (token.rows.length) {
+            if (singleTBody) output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {
               row = token.rows[i];
               col = 0;
+              if (singleTBody) output += '<tr>';
               let trContents = '';
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                if (singleTBody) output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                else trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                 col += cell.colspan;
               }
-              if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
+              if (singleTBody) output += '</tr>';
+              else if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
             }
+            if (singleTBody) output += '</tbody>';
           }
           output += '</table>';
           return output;

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -120,20 +120,18 @@
             }
             output += '</thead>';
             if (token.rows.length) {
-              output += '<tbody>';
               for (i = 0; i < token.rows.length; i++) {
                 row = token.rows[i];
                 col = 0;
-                output += '<tr>';
+                let trContents = '';
                 for (j = 0; j < row.length; j++) {
                   cell = row[j];
                   text = this.parser.parseInline(cell.tokens);
-                  output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                  trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                   col += cell.colspan;
                 }
-                output += '</tr>';
+                if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
               }
-              output += '</tbody>';
             }
             output += '</table>';
             return output;

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -4,12 +4,15 @@
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global["extended-tables"] = factory());
 })(this, (function () { 'use strict';
 
+  let singleTBody = true;
+
   function index(endRegex = []) {
     return {
       extensions: [
         {
           name: 'spanTable',
           level: 'block', // Is this a block-level or inline-level tokenizer?
+          setMode(mode) { if (typeof mode === 'boolean') singleTBody = mode; },
           start(src) { return src.match(/^\n *([^\n ].*\|.*)\n/)?.index; }, // Hint to Marked.js to stop and check for a match
           tokenizer(src, tokens) {
             // const regex = this.tokenizer.rules.block.table;
@@ -120,18 +123,23 @@
             }
             output += '</thead>';
             if (token.rows.length) {
+              if (singleTBody) output += '<tbody>';
               for (i = 0; i < token.rows.length; i++) {
                 row = token.rows[i];
                 col = 0;
+                if (singleTBody) output += '<tr>';
                 let trContents = '';
                 for (j = 0; j < row.length; j++) {
                   cell = row[j];
                   text = this.parser.parseInline(cell.tokens);
-                  trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                  if (singleTBody) output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                  else trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                   col += cell.colspan;
                 }
-                if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
+                if (singleTBody) output += '</tr>';
+                else if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
               }
+              if (singleTBody) output += '</tbody>';
             }
             output += '</table>';
             return output;

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`extended-table Column Spanning 1`] = `
 </tr></tbody></table>"
 `;
 
-exports[`extended-table Drops empty TRs 1`] = `
+exports[`extended-table Drops empty TRs in multiple tbody Mode 1`] = `
 "<table><thead><tr><th align=left>Race</th>
 <th align=left>Multi-class options</th>
 </tr></thead><tbody><tr><td align=left>Dwarf</td>
@@ -22,6 +22,24 @@ exports[`extended-table Drops empty TRs 1`] = `
 </tr></tbody><tbody><tr><td align=left>Halfling</td>
 <td align=left>fighter/thief</td>
 </tr></tbody><tbody><tr><td align=left>Human</td>
+<td align=left>none</td>
+</tr></tbody></table>"
+`;
+
+exports[`extended-table Leave empty TRs in single tbody Mode 1`] = `
+"<table><thead><tr><th align=left>Race</th>
+<th align=left>Multi-class options</th>
+</tr></thead><tbody><tr><td align=left>Dwarf</td>
+<td align=left>fighter/cleric, fighter/thief</td>
+</tr><tr><td rowspan=2 align=left>Elf </td>
+<td rowspan=2 align=left>fighter/mage, fighter/thief, mage/thief, fighter/mage/thief                                         </td>
+</tr><tr></tr><tr><td rowspan=2 align=left>Gnome </td>
+<td rowspan=2 align=left>fighter/thief, fighter/cleric, fighter/illusionist, thief/cleric, thief/illusionist, cleric/illusionist        </td>
+</tr><tr></tr><tr><td rowspan=3 align=left>Half-elf  </td>
+<td rowspan=3 align=left>fighter/priest, fighter/mage, fighter/thief, ranger/priest, mage/priest, mage/thief,                                    fighter/mage/priest, fighter/mage/thief                    </td>
+</tr><tr></tr><tr></tr><tr><td align=left>Halfling</td>
+<td align=left>fighter/thief</td>
+</tr><tr><td align=left>Human</td>
 <td align=left>none</td>
 </tr></tbody></table>"
 `;
@@ -41,8 +59,8 @@ exports[`extended-table Row Spanning 1`] = `
 <th>H2</th>
 </tr></thead><tbody><tr><td rowspan=3>This cell spans three  rows        </td>
 <td>Cell A</td>
-</tr></tbody><tbody><tr><td>Cell B</td>
-</tr></tbody><tbody><tr><td>Cell C</td>
+</tr><tr><td>Cell B</td>
+</tr><tr><td>Cell C</td>
 </tr></tbody></table>"
 `;
 

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -76,24 +76,6 @@ exports[`extended-table Works with combined widths and alignment 1`] = `
 </tr></tbody></table>"
 `;
 
-exports[`extended-table Works with combined widths and alignment 2`] = `
-"<table><thead><tr><th align=left>Race</th>
-<th align=left>Multi-class options</th>
-</tr></thead><tbody><tr><td align=left>Dwarf</td>
-<td align=left>fighter/cleric, fighter/thief</td>
-</tr></tbody><tbody><tr><td rowspan=2 align=left>Elf </td>
-<td rowspan=2 align=left>fighter/mage, fighter/thief, mage/thief, fighter/mage/thief                                         </td>
-</tr></tbody><tbody><tr><td rowspan=2 align=left>Gnome </td>
-<td rowspan=2 align=left>fighter/thief, fighter/cleric, fighter/illusionist, thief/cleric, thief/illusionist, cleric/illusionist        </td>
-</tr></tbody><tbody><tr><td rowspan=3 align=left>Half-elf  </td>
-<td rowspan=3 align=left>fighter/priest, fighter/mage, fighter/thief, ranger/priest, mage/priest, mage/thief,                                    fighter/mage/priest, fighter/mage/thief                    </td>
-</tr></tbody><tbody><tr><td align=left>Halfling</td>
-<td align=left>fighter/thief</td>
-</tr></tbody><tbody><tr><td align=left>Human</td>
-<td align=left>none</td>
-</tr></tbody></table>"
-`;
-
 exports[`extended-table Works with minimal delimiter rows 1`] = `
 "<table><thead><tr><th>Header A</th>
 <th align=left>Header B</th>

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -8,6 +8,24 @@ exports[`extended-table Column Spanning 1`] = `
 </tr></tbody></table>"
 `;
 
+exports[`extended-table Drops empty TRs 1`] = `
+"<table><thead><tr><th align=left>Race</th>
+<th align=left>Multi-class options</th>
+</tr></thead><tbody><tr><td align=left>Dwarf</td>
+<td align=left>fighter/cleric, fighter/thief</td>
+</tr></tbody><tbody><tr><td rowspan=2 align=left>Elf </td>
+<td rowspan=2 align=left>fighter/mage, fighter/thief, mage/thief, fighter/mage/thief                                         </td>
+</tr></tbody><tbody><tr><td rowspan=2 align=left>Gnome </td>
+<td rowspan=2 align=left>fighter/thief, fighter/cleric, fighter/illusionist, thief/cleric, thief/illusionist, cleric/illusionist        </td>
+</tr></tbody><tbody><tr><td rowspan=3 align=left>Half-elf  </td>
+<td rowspan=3 align=left>fighter/priest, fighter/mage, fighter/thief, ranger/priest, mage/priest, mage/thief,                                    fighter/mage/priest, fighter/mage/thief                    </td>
+</tr></tbody><tbody><tr><td align=left>Halfling</td>
+<td align=left>fighter/thief</td>
+</tr></tbody><tbody><tr><td align=left>Human</td>
+<td align=left>none</td>
+</tr></tbody></table>"
+`;
+
 exports[`extended-table Multi-row headers 1`] = `
 "<table><thead><tr><th colspan=2 rowspan=2>This header spans two columns <em>and</em> two rows </th>
 <th>Header A</th>
@@ -23,8 +41,8 @@ exports[`extended-table Row Spanning 1`] = `
 <th>H2</th>
 </tr></thead><tbody><tr><td rowspan=3>This cell spans three  rows        </td>
 <td>Cell A</td>
-</tr><tr><td>Cell B</td>
-</tr><tr><td>Cell C</td>
+</tr></tbody><tbody><tr><td>Cell B</td>
+</tr></tbody><tbody><tr><td>Cell C</td>
 </tr></tbody></table>"
 `;
 
@@ -55,6 +73,24 @@ exports[`extended-table Works with combined widths and alignment 1`] = `
 </tr></thead><tbody><tr><td align=left width=10%>Cell A</td>
 <td align=center width=20%>Cell B</td>
 <td align=right width=50%>Cell C</td>
+</tr></tbody></table>"
+`;
+
+exports[`extended-table Works with combined widths and alignment 2`] = `
+"<table><thead><tr><th align=left>Race</th>
+<th align=left>Multi-class options</th>
+</tr></thead><tbody><tr><td align=left>Dwarf</td>
+<td align=left>fighter/cleric, fighter/thief</td>
+</tr></tbody><tbody><tr><td rowspan=2 align=left>Elf </td>
+<td rowspan=2 align=left>fighter/mage, fighter/thief, mage/thief, fighter/mage/thief                                         </td>
+</tr></tbody><tbody><tr><td rowspan=2 align=left>Gnome </td>
+<td rowspan=2 align=left>fighter/thief, fighter/cleric, fighter/illusionist, thief/cleric, thief/illusionist, cleric/illusionist        </td>
+</tr></tbody><tbody><tr><td rowspan=3 align=left>Half-elf  </td>
+<td rowspan=3 align=left>fighter/priest, fighter/mage, fighter/thief, ranger/priest, mage/priest, mage/thief,                                    fighter/mage/priest, fighter/mage/thief                    </td>
+</tr></tbody><tbody><tr><td align=left>Halfling</td>
+<td align=left>fighter/thief</td>
+</tr></tbody><tbody><tr><td align=left>Human</td>
+<td align=left>none</td>
 </tr></tbody></table>"
 `;
 

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -98,8 +98,28 @@ describe('extended-table', () => {
     `))).toMatchSnapshot();
   });
 
-  test('Drops empty TRs', () => {
+  test('Drops empty TRs in multiple tbody Mode', () => {
     marked.use(extendedTable());
+    extendedTable().extensions[0].setMode(false);
+    expect(marked(trimLines(`
+      | Race     | Multi-class options                                         |
+      |:---------|:------------------------------------------------------------|
+      | Dwarf    | fighter/cleric, fighter/thief                               |
+      | Elf      | fighter/mage, fighter/thief, mage/thief,                    |
+      |         ^| fighter/mage/thief                                         ^|
+      | Gnome    | fighter/thief, fighter/cleric, fighter/illusionist,         | 
+      |         ^| thief/cleric, thief/illusionist, cleric/illusionist        ^|
+      | Half-elf | fighter/priest, fighter/mage, fighter/thief, ranger/priest, |
+      |         ^| mage/priest, mage/thief,                                   ^|
+      |         ^| fighter/mage/priest, fighter/mage/thief                    ^|
+      | Halfling | fighter/thief                                               |
+      | Human    | none                                                        |
+    `))).toMatchSnapshot();
+  });
+
+  test('Leave empty TRs in single tbody Mode', () => {
+    marked.use(extendedTable());
+    extendedTable().extensions[0].setMode(true);
     expect(marked(trimLines(`
       | Race     | Multi-class options                                         |
       |:---------|:------------------------------------------------------------|

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -97,4 +97,22 @@ describe('extended-table', () => {
       | Cell A   | Cell B   | Cell C   |
     `))).toMatchSnapshot();
   });
+
+  test('Drops empty TRs', () => {
+    marked.use(extendedTable());
+    expect(marked(trimLines(`
+      | Race     | Multi-class options                                         |
+      |:---------|:------------------------------------------------------------|
+      | Dwarf    | fighter/cleric, fighter/thief                               |
+      | Elf      | fighter/mage, fighter/thief, mage/thief,                    |
+      |         ^| fighter/mage/thief                                         ^|
+      | Gnome    | fighter/thief, fighter/cleric, fighter/illusionist,         | 
+      |         ^| thief/cleric, thief/illusionist, cleric/illusionist        ^|
+      | Half-elf | fighter/priest, fighter/mage, fighter/thief, ranger/priest, |
+      |         ^| mage/priest, mage/thief,                                   ^|
+      |         ^| fighter/mage/priest, fighter/mage/thief                    ^|
+      | Halfling | fighter/thief                                               |
+      | Human    | none                                                        |
+    `))).toMatchSnapshot();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,12 @@
+let singleTBody = true;
+
 export default function(endRegex = []) {
   return {
     extensions: [
       {
         name: 'spanTable',
         level: 'block', // Is this a block-level or inline-level tokenizer?
+        setMode(mode) { if (typeof mode === 'boolean') singleTBody = mode; },
         start(src) { return src.match(/^\n *([^\n ].*\|.*)\n/)?.index; }, // Hint to Marked.js to stop and check for a match
         tokenizer(src, tokens) {
           // const regex = this.tokenizer.rules.block.table;
@@ -114,18 +117,23 @@ export default function(endRegex = []) {
           }
           output += '</thead>';
           if (token.rows.length) {
+            if (singleTBody) output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {
               row = token.rows[i];
               col = 0;
+              if (singleTBody) output += '<tr>';
               let trContents = '';
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                if (singleTBody) output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                else trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                 col += cell.colspan;
               }
-              if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
+              if (singleTBody) output += '</tr>';
+              else if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
             }
+            if (singleTBody) output += '</tbody>';
           }
           output += '</table>';
           return output;

--- a/src/index.js
+++ b/src/index.js
@@ -114,20 +114,18 @@ export default function(endRegex = []) {
           }
           output += '</thead>';
           if (token.rows.length) {
-            output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {
               row = token.rows[i];
               col = 0;
-              output += '<tr>';
+              let trContents = '';
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                trContents += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
                 col += cell.colspan;
               }
-              output += '</tr>';
+              if (trContents.length > 0) output += `<tbody><tr>${trContents}</tr></tbody>`;
             }
-            output += '</tbody>';
           }
           output += '</table>';
           return output;


### PR DESCRIPTION
When the entirety of a row is shifted up the resulting structure has an empty <tr></tr> pair after the completed row. This causes nth-child-based CSS to be, well, wrong if you don't pad to account for it.

This fix wraps <tr></tr> in <tbody></tbody> and drops the empty <tr></tr> sets. This allows the CSS to be set on the <tbody> instead of the <tr> for the desired effects.

This MAY be a breaking change for CSS applied to the table.

Created to solve for https://github.com/naturalcrit/homebrewery/issues/1729