### PR TITLE
Workable implementation of dropping table thead from table results.

### DIFF
--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -101,20 +101,23 @@ function index(endRegex = []) {
         renderer(token) {
           let i, j, row, cell, col, text;
           let output = '<table>';
-          output += '<thead>';
+          let headerOutput = '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];
             let col = 0;
-            output += '<tr>';
+            headerOutput += '<tr>';
             for (j = 0; j < row.length; j++) {
               cell = row[j];
               text = this.parser.parseInline(cell.tokens);
-              output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
+              const cellOutput = getTableCell(text, cell, 'th', token.align[col], token.width[col]);
+              if (cellOutput) headerOutput += cellOutput;
+              else break;
               col += cell.colspan;
             }
-            output += '</tr>';
+            headerOutput += '</tr>';
           }
-          output += '</thead>';
+          headerOutput += '</thead>';
+          if (headerOutput !== '<thead><tr></tr></thead>') output += headerOutput;
           if (token.rows.length) {
             output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {
@@ -143,6 +146,7 @@ const getTableCell = (text, cell, type, align, width) => {
   if (!cell.rowspan) {
     return '';
   }
+  if (text[0] === '!') return undefined;
   const tag = `<${type}`
             + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
             + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -105,20 +105,23 @@
           renderer(token) {
             let i, j, row, cell, col, text;
             let output = '<table>';
-            output += '<thead>';
+            let headerOutput = '<thead>';
             for (i = 0; i < token.header.length; i++) {
               row = token.header[i];
               let col = 0;
-              output += '<tr>';
+              headerOutput += '<tr>';
               for (j = 0; j < row.length; j++) {
                 cell = row[j];
                 text = this.parser.parseInline(cell.tokens);
-                output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
+                const cellOutput = getTableCell(text, cell, 'th', token.align[col], token.width[col]);
+                if (cellOutput) headerOutput += cellOutput;
+                else break;
                 col += cell.colspan;
               }
-              output += '</tr>';
+              headerOutput += '</tr>';
             }
-            output += '</thead>';
+            headerOutput += '</thead>';
+            if (headerOutput !== '<thead><tr></tr></thead>') output += headerOutput;
             if (token.rows.length) {
               output += '<tbody>';
               for (i = 0; i < token.rows.length; i++) {
@@ -147,6 +150,7 @@
     if (!cell.rowspan) {
       return '';
     }
+    if (text[0] === '!') return undefined;
     const tag = `<${type}`
               + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
               + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`

--- a/src/index.js
+++ b/src/index.js
@@ -108,8 +108,8 @@ export default function(endRegex = []) {
               cell = row[j];
               text = this.parser.parseInline(cell.tokens);
               const cellOutput = getTableCell(text, cell, 'th', token.align[col], token.width[col]);
-              if (cellOutput) headerOutput += cellOutput;
-              else break;
+              if (cellOutput !== undefined) headerOutput += cellOutput;
+              else if (j === 0) break;
               col += cell.colspan;
             }
             headerOutput += '</tr>';

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ const getTableCell = (text, cell, type, align, width) => {
   if (!cell.rowspan) {
     return '';
   }
-  if (text[0] === '!') return undefined;
+  if ((text[0] === '!') && (type === 'th')) return undefined;
   const tag = `<${type}`
             + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
             + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`

--- a/src/index.js
+++ b/src/index.js
@@ -99,20 +99,23 @@ export default function(endRegex = []) {
         renderer(token) {
           let i, j, row, cell, col, text;
           let output = '<table>';
-          output += '<thead>';
+          let headerOutput = '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];
             let col = 0;
-            output += '<tr>';
+            headerOutput += '<tr>';
             for (j = 0; j < row.length; j++) {
               cell = row[j];
               text = this.parser.parseInline(cell.tokens);
-              output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
+              const cellOutput = getTableCell(text, cell, 'th', token.align[col], token.width[col]);
+              if (cellOutput) headerOutput += cellOutput;
+              else break;
               col += cell.colspan;
             }
-            output += '</tr>';
+            headerOutput += '</tr>';
           }
-          output += '</thead>';
+          headerOutput += '</thead>';
+          if (headerOutput !== '<thead><tr></tr></thead>') output += headerOutput;
           if (token.rows.length) {
             output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {
@@ -141,6 +144,7 @@ const getTableCell = (text, cell, type, align, width) => {
   if (!cell.rowspan) {
     return '';
   }
+  if (text[0] === '!') return undefined;
   const tag = `<${type}`
             + `${cell.colspan > 1 ? ` colspan=${cell.colspan}` : ''}`
             + `${cell.rowspan > 1 ? ` rowspan=${cell.rowspan}` : ''}`


### PR DESCRIPTION
This adds a new control character for Table headers that drops the thead section from the resulting output.

```
|!| | |
|-|-|-|
|dasd|asdasd|
|asdasd|asdasdas|
```

Renders

```
<table><tbody><tr><td>dasd</td>
<td>asdasd</td>
<td></td>
</tr><tr><td>asdasd</td>
<td>asdasdas</td>
<td></td>
</tr></tbody></table>
```

Rationale:

This extension requires a header row to parse a table even if the user does not desire one. The current best solution is to CSS the header away.