### PR TITLE
Remove empty rows from output

### DIFF
--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -18,6 +18,14 @@ exports[`extended-table Multi-row headers 1`] = `
 </tr></tbody></table>"
 `;
 
+exports[`extended-table Row Merging - Full 1`] = `
+"<table><thead><tr><th>H1</th>
+<th>H2</th>
+</tr></thead><tbody><tr><td>Merge empty rows 1                 </td>
+<td>Cell A Cell B  </td>
+</tr></tbody></table>"
+`;
+
 exports[`extended-table Row Spanning 1`] = `
 "<table><thead><tr><th>H1</th>
 <th>H2</th>

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -30,6 +30,17 @@ describe('extended-table', () => {
     `))).toMatchSnapshot();
   });
 
+  test('Row Merging - Full', () => {
+    marked.use(extendedTable());
+    expect(marked(trimLines(`
+      | H1                | H2      |
+      |-------------------|---------|
+      | Merge empty rows  | Cell A  |
+      | 1                ^| Cell B ^|
+      |                  ^|        ^|
+    `))).toMatchSnapshot();
+  });
+
   test('Multi-row headers', () => {
     marked.use(extendedTable());
     expect(marked(trimLines(`

--- a/src/index.js
+++ b/src/index.js
@@ -118,14 +118,16 @@ export default function(endRegex = []) {
             for (i = 0; i < token.rows.length; i++) {
               row = token.rows[i];
               col = 0;
-              output += '<tr>';
-              for (j = 0; j < row.length; j++) {
-                cell = row[j];
-                text = this.parser.parseInline(cell.tokens);
-                output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
-                col += cell.colspan;
+              if (!row[0].emptyRow) {
+                output += '<tr>';
+                for (j = 0; j < row.length; j++) {
+                  cell = row[j];
+                  text = this.parser.parseInline(cell.tokens);
+                  output += getTableCell(text, cell, 'td', token.align[col], token.width[col]);
+                  col += cell.colspan;
+                }
+                output += '</tr>';
               }
-              output += '</tr>';
             }
             output += '</tbody>';
           }
@@ -188,6 +190,14 @@ const splitCells = (tableRow, count, prevRow = []) => {
     }
 
     numCols += cells[i].colspan;
+  }
+
+  // If all cells have been merged, flag as an empty row
+  if (cells.length === cells.filter((cell) => { return cell.rowspan === 0; }).length) {
+    cells[0].emptyRow = true;
+    for (i = 0; i < cells.length; i++) {
+      cells[i].rowSpanTarget.rowspan -= 1;
+    }
   }
 
   // Force main cell rows to match header column count


### PR DESCRIPTION
This PR seeks to resolve https://github.com/naturalcrit/homebrewery/issues/1729.

This PR checks for empty rows in the HTML output - `<tr></tr>` - and removes these from the output. It also walks all cells in the affected row and updates the `rowspan` property of each cell's rowSpanTarget, decreasing the property by 1 (as one cell has been removed from the number of rows to be spanned).

This PR also adds a test to check that the empty row is correctly removed from the output.