### PR TITLE
Fix crash caused by new skip empty row function

### DIFF
--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -195,7 +195,7 @@ const splitCells = (tableRow, count, prevRow = [], skipEmptyRows) => {
   }
 
   // If all cells have been merged, flag as an empty row
-  if (skipEmptyRows && cells.length === cells.filter((cell) => { return cell.rowspan === 0; }).length) {
+  if (cells.length > 0 && skipEmptyRows && cells.length === cells.filter((cell) => { return cell.rowspan === 0; }).length) {
     cells[0].emptyRow = true;
     for (i = 0; i < cells.length; i++) {
       cells[i].rowSpanTarget.rowspan -= 1;

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -199,7 +199,7 @@
     }
 
     // If all cells have been merged, flag as an empty row
-    if (skipEmptyRows && cells.length === cells.filter((cell) => { return cell.rowspan === 0; }).length) {
+    if (cells.length > 0 && skipEmptyRows && cells.length === cells.filter((cell) => { return cell.rowspan === 0; }).length) {
       cells[0].emptyRow = true;
       for (i = 0; i < cells.length; i++) {
         cells[i].rowSpanTarget.rowspan -= 1;

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -8,6 +8,16 @@ exports[`extended-table Column Spanning 1`] = `
 </tr></tbody></table>"
 `;
 
+exports[`extended-table Incomplete Row 1`] = `
+"<table><thead><tr><th>H1</th>
+<th>H2</th>
+</tr></thead><tbody><tr><td>Merge empty rows</td>
+<td>Cell A</td>
+</tr><tr><td></td>
+<td></td>
+</tr></tbody></table>"
+`;
+
 exports[`extended-table Multi-row headers 1`] = `
 "<table><thead><tr><th colspan=2 rowspan=2>This header spans two columns <em>and</em> two rows </th>
 <th>Header A</th>

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -83,6 +83,16 @@ describe('extended-table', () => {
     `))).toMatchSnapshot();
   });
 
+  test('Incomplete Row', () => {
+    marked.use(extendedTable({}));
+    expect(marked(trimLines(`
+      | H1                | H2      |
+      |-------------------|---------|
+      | Merge empty rows  | Cell A  |
+      |
+    `))).toMatchSnapshot();
+  });
+
   test('Multi-row headers', () => {
     marked.use(extendedTable());
     expect(marked(trimLines(`

--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,7 @@ const splitCells = (tableRow, count, prevRow = [], skipEmptyRows) => {
   }
 
   // If all cells have been merged, flag as an empty row
-  if (skipEmptyRows && cells.length === cells.filter((cell) => { return cell.rowspan === 0; }).length) {
+  if (cells.length > 0 && skipEmptyRows && cells.length === cells.filter((cell) => { return cell.rowspan === 0; }).length) {
     cells[0].emptyRow = true;
     for (i = 0; i < cells.length; i++) {
       cells[i].rowSpanTarget.rowspan -= 1;


### PR DESCRIPTION
This PR resolves an issue where incomplete table rows were causing a crash.

In short, when a table row existed (indicated by `|`) but no cells existed in that row, the logic to apply the empty row skip would trigger - but as no cells existed to apply the skip to, it would instead crash. This PR simply adds a check that there is a non-zero number of cells before applying the skip.

This PR also adds a test for an incomplete row on cells, to ensure that the output works correctly in any future updates.