### PR TITLE
Add automatic colgroup and cols

### DIFF
--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -99,15 +99,8 @@ function index({ interruptPatterns = [], skipEmptyRows = true, colGroups = false
           }
         },
         renderer(token) {
-          let i, j, row, cell, col, text;
+          let i, j, row, cell, col, text, maxCol = 0;
           let output = '<table>';
-          if (colGroups) {
-            output += '<colGroup>';
-            for (i = 0; i < Math.max(token.header?.map((header) => { return header.length; }) || 1); i++) {
-              output += `<col class='column${i + 1}' />`;
-            }
-            output += '</colGroup>';
-          }
           output += '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];
@@ -118,10 +111,18 @@ function index({ interruptPatterns = [], skipEmptyRows = true, colGroups = false
               text = this.parser.parseInline(cell.tokens);
               output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
               col += cell.colspan;
+              maxCol = j > maxCol ? j : maxCol;
             }
             output += '</tr>';
           }
           output += '</thead>';
+          if (colGroups) {
+            output += '<colGroup>';
+            for (i = 0; i < maxCol + 1; i++) {
+              output += `<col class='column${i + 1}' />`;
+            }
+            output += '</colGroup>';
+          }
           if (token.rows.length) {
             output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-function index({ interruptPatterns = [], skipEmptyRows = true } = {}) {
+function index({ interruptPatterns = [], skipEmptyRows = true, colGroups = false } = {}) {
   return {
     extensions: [
       {
@@ -101,6 +101,13 @@ function index({ interruptPatterns = [], skipEmptyRows = true } = {}) {
         renderer(token) {
           let i, j, row, cell, col, text;
           let output = '<table>';
+          if (colGroups) {
+            output += '<colGroup>';
+            for (i = 0; i < Math.max(token.header?.map((header) => { return header.length; }) || 1); i++) {
+              output += `<col class='column${i + 1}' />`;
+            }
+            output += '</colGroup>';
+          }
           output += '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -4,7 +4,7 @@
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global["extended-tables"] = factory());
 })(this, (function () { 'use strict';
 
-  function index({ interruptPatterns = [], skipEmptyRows = true } = {}) {
+  function index({ interruptPatterns = [], skipEmptyRows = true, colGroups = false } = {}) {
     return {
       extensions: [
         {
@@ -105,6 +105,13 @@
           renderer(token) {
             let i, j, row, cell, col, text;
             let output = '<table>';
+            if (colGroups) {
+              output += '<colGroup>';
+              for (i = 0; i < Math.max(token.header?.map((header) => { return header.length; }) || 1); i++) {
+                output += `<col class='column${i + 1}' />`;
+              }
+              output += '</colGroup>';
+            }
             output += '<thead>';
             for (i = 0; i < token.header.length; i++) {
               row = token.header[i];

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -103,15 +103,8 @@
             }
           },
           renderer(token) {
-            let i, j, row, cell, col, text;
+            let i, j, row, cell, col, text, maxCol = 0;
             let output = '<table>';
-            if (colGroups) {
-              output += '<colGroup>';
-              for (i = 0; i < Math.max(token.header?.map((header) => { return header.length; }) || 1); i++) {
-                output += `<col class='column${i + 1}' />`;
-              }
-              output += '</colGroup>';
-            }
             output += '<thead>';
             for (i = 0; i < token.header.length; i++) {
               row = token.header[i];
@@ -122,10 +115,18 @@
                 text = this.parser.parseInline(cell.tokens);
                 output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
                 col += cell.colspan;
+                maxCol = j > maxCol ? j : maxCol;
               }
               output += '</tr>';
             }
             output += '</thead>';
+            if (colGroups) {
+              output += '<colGroup>';
+              for (i = 0; i < maxCol + 1; i++) {
+                output += `<col class='column${i + 1}' />`;
+              }
+              output += '</colGroup>';
+            }
             if (token.rows.length) {
               output += '<tbody>';
               for (i = 0; i < token.rows.length; i++) {

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`extended-table Colgroups added to header 1`] = `
+"<table><colGroup><col class='column1' /><col class='column2' /></colGroup><thead><tr><th>Header A</th>
+<th>Header B</th>
+</tr></thead><tbody><tr><td>Cell A</td>
+<td>Cell B</td>
+</tr><tr><td>aaaa</td>
+<td></td>
+</tr><tr><td>bbbb</td>
+<td></td>
+</tr><tr><td>cccc</td>
+<td></td>
+</tr></tbody></table>"
+`;
+
 exports[`extended-table Column Spanning 1`] = `
 "<table><thead><tr><th>H1</th>
 <th>H2</th>

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`extended-table Colgroups added to header 1`] = `
-"<table><colGroup><col class='column1' /><col class='column2' /></colGroup><thead><tr><th>Header A</th>
+"<table><thead><tr><th>Header A</th>
 <th>Header B</th>
-</tr></thead><tbody><tr><td>Cell A</td>
+</tr></thead><colGroup><col class='column1' /><col class='column2' /></colGroup><tbody><tr><td>Cell A</td>
 <td>Cell B</td>
 </tr><tr><td>aaaa</td>
 <td></td>

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -179,4 +179,16 @@ describe('extended-table', () => {
       | A1    | B1 |
     `))).toMatchSnapshot();
   });
+
+  test('Colgroups added to header', () => {
+    marked.use(extendedTable({ colGroups: true }));
+    expect(marked(trimLines(`
+      | Header A | Header B |
+      |----------|----------|
+      | Cell A   | Cell B   |
+      aaaa
+      bbbb
+      cccc
+    `))).toMatchSnapshot();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -97,15 +97,8 @@ export default function({ interruptPatterns = [], skipEmptyRows = true, colGroup
           }
         },
         renderer(token) {
-          let i, j, row, cell, col, text;
+          let i, j, row, cell, col, text, maxCol = 0;
           let output = '<table>';
-          if (colGroups) {
-            output += '<colGroup>';
-            for (i = 0; i < Math.max(token.header?.map((header) => { return header.length; }) || 1); i++) {
-              output += `<col class='column${i + 1}' />`;
-            }
-            output += '</colGroup>';
-          }
           output += '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];
@@ -116,10 +109,18 @@ export default function({ interruptPatterns = [], skipEmptyRows = true, colGroup
               text = this.parser.parseInline(cell.tokens);
               output += getTableCell(text, cell, 'th', token.align[col], token.width[col]);
               col += cell.colspan;
+              maxCol = j > maxCol ? j : maxCol;
             }
             output += '</tr>';
           }
           output += '</thead>';
+          if (colGroups) {
+            output += '<colGroup>';
+            for (i = 0; i < maxCol + 1; i++) {
+              output += `<col class='column${i + 1}' />`;
+            }
+            output += '</colGroup>';
+          }
           if (token.rows.length) {
             output += '<tbody>';
             for (i = 0; i < token.rows.length; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function({ interruptPatterns = [], skipEmptyRows = true } = {}) {
+export default function({ interruptPatterns = [], skipEmptyRows = true, colGroups = false } = {}) {
   return {
     extensions: [
       {
@@ -99,6 +99,13 @@ export default function({ interruptPatterns = [], skipEmptyRows = true } = {}) {
         renderer(token) {
           let i, j, row, cell, col, text;
           let output = '<table>';
+          if (colGroups) {
+            output += '<colGroup>';
+            for (i = 0; i < token.header.length; i++) {
+              output += `<col class='column${i}' />`;
+            }
+            output += '</colGroup>';
+          }
           output += '<thead>';
           for (i = 0; i < token.header.length; i++) {
             row = token.header[i];

--- a/src/index.js
+++ b/src/index.js
@@ -101,8 +101,8 @@ export default function({ interruptPatterns = [], skipEmptyRows = true, colGroup
           let output = '<table>';
           if (colGroups) {
             output += '<colGroup>';
-            for (i = 0; i < token.header.length; i++) {
-              output += `<col class='column${i}' />`;
+            for (i = 0; i < Math.max(token.header?.map((header) => { return header.length; }) || 1); i++) {
+              output += `<col class='column${i + 1}' />`;
             }
             output += '</colGroup>';
           }


### PR DESCRIPTION
With support for row spanning, it has become difficult for users to target an entire column of cells (as `td:nth-of-type()` is inconsistent). This PR adds a `<colgroup>` with one `<col>`  for every element in the headers. Each `<col>` has a class applied, `column1`, `column2`, and so on, to allow styling by end users.